### PR TITLE
Some code improvements

### DIFF
--- a/envconfig.go
+++ b/envconfig.go
@@ -305,7 +305,7 @@ func processField(value string, field reflect.Value) error {
 		sl := reflect.MakeSlice(typ, 0, 0)
 		if typ.Elem().Kind() == reflect.Uint8 {
 			sl = reflect.ValueOf([]byte(value))
-		} else if len(strings.TrimSpace(value)) != 0 {
+		} else if strings.TrimSpace(value) != "" {
 			vals := strings.Split(value, ",")
 			sl = reflect.MakeSlice(typ, len(vals), len(vals))
 			for i, val := range vals {
@@ -318,7 +318,7 @@ func processField(value string, field reflect.Value) error {
 		field.Set(sl)
 	case reflect.Map:
 		mp := reflect.MakeMap(typ)
-		if len(strings.TrimSpace(value)) != 0 {
+		if strings.TrimSpace(value) != "" {
 			pairs := strings.Split(value, ",")
 			for _, pair := range pairs {
 				kvpair := strings.Split(pair, ":")

--- a/envconfig_test.go
+++ b/envconfig_test.go
@@ -794,7 +794,7 @@ func TestCheckDisallowedIgnored(t *testing.T) {
 
 func TestErrorMessageForRequiredAltVar(t *testing.T) {
 	var s struct {
-		Foo    string `envconfig:"BAR" required:"true"`
+		Foo string `envconfig:"BAR" required:"true"`
 	}
 
 	os.Clearenv()

--- a/usage_test.go
+++ b/usage_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 }
 
 func compareUsage(want, got string, t *testing.T) {
-	got = strings.Replace(got, " ", ".", -1)
+	got = strings.ReplaceAll(got, " ", ".")
 	if want != got {
 		shortest := len(want)
 		if len(got) < shortest {
@@ -137,7 +137,7 @@ func TestUsageUnknownKeyFormat(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected 'unknown key' error, but got no error")
 	}
-	if strings.Index(err.Error(), unknownError) == -1 {
+	if !strings.Contains(err.Error(), unknownError) {
 		t.Errorf("expected '%s', but got '%s'", unknownError, err.Error())
 	}
 }


### PR DESCRIPTION
* Rewrite empty string checks more idiomatically.
* gofmt envconfig_test.go file.
* Fix typo in specified word.
* strings.ReplaceAll instead of strings.Replace with -1.
* !strings.Contains instead of strings.Index == -1 comparison.